### PR TITLE
Add support for --types

### DIFF
--- a/pre_commit_mirror_maker/all/.pre-commit-hooks.yaml
+++ b/pre_commit_mirror_maker/all/.pre-commit-hooks.yaml
@@ -2,5 +2,5 @@
     name: {name}
     entry: {entry}
     language: {language}
-    files: {files}
+    '{match_key}': {match_val}
     args: {args}

--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -22,7 +22,7 @@ def python_get_package_versions(package_name):
     return list(reversed(versions))
 
 
-VERSION_LIST_FUNCTIONS = {
+LIST_VERSIONS = {
     'node': node_get_package_versions,
     'python': python_get_package_versions,
     'ruby': ruby_get_package_versions,

--- a/pre_commit_mirror_maker/node/.pre-commit-hooks.yaml
+++ b/pre_commit_mirror_maker/node/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: {name}
     entry: {entry}
     language: {language}
-    files: {files}
+    '{match_key}': {match_val}
     args: {args}
     # Use additional_dependencies to install the actual node package
     additional_dependencies: ['{name}@{version}']

--- a/tests/make_repo_test.py
+++ b/tests/make_repo_test.py
@@ -1,4 +1,3 @@
-import os.path
 import subprocess
 import sys
 from unittest import mock
@@ -6,9 +5,9 @@ from unittest import mock
 import pytest
 import yaml
 
-from pre_commit_mirror_maker.make_repo import _apply_version_and_commit
-from pre_commit_mirror_maker.make_repo import cwd
-from pre_commit_mirror_maker.make_repo import format_files_to_directory
+from pre_commit_mirror_maker.languages import LIST_VERSIONS
+from pre_commit_mirror_maker.make_repo import _commit_version
+from pre_commit_mirror_maker.make_repo import format_files
 from pre_commit_mirror_maker.make_repo import make_repo
 
 
@@ -16,7 +15,7 @@ def _cmd(*cmd):
     return subprocess.check_output(cmd).strip().decode()
 
 
-def test_format_files_to_directory(tmpdir):
+def test_format_files(tmpdir):
     src = tmpdir.join('src').ensure_dir()
     dest = tmpdir.join('dest').ensure_dir()
 
@@ -24,21 +23,21 @@ def test_format_files_to_directory(tmpdir):
     src.join('file2.txt').write('hello world')
     src.join('file3.txt').write('foo bar {baz}')
 
-    format_files_to_directory(src, dest, {'foo': 'herp', 'baz': 'derp'})
+    format_files(src, dest, foo='herp', baz='derp')
 
     assert dest.join('file1.txt').read() == 'herp bar derp'
     assert dest.join('file2.txt').read() == 'hello world'
     assert dest.join('file3.txt').read() == 'foo bar derp'
 
 
-def test_format_files_to_directory_skips_pyc(tmpdir):
+def test_format_files_skips_pyc(tmpdir):
     src = tmpdir.join('src').ensure_dir()
     dest = tmpdir.join('dest').ensure_dir()
 
     src.join('setup.py').write('# Setup.py')
     src.join('setup.pyc').write("# Setup.pyc, don't copy me!")
 
-    format_files_to_directory(src, dest, {})
+    format_files(src, dest)
 
     assert dest.join('setup.py').exists()
     assert not dest.join('setup.pyc').exists()
@@ -49,15 +48,8 @@ def test_skips_directories(tmpdir):
     dest = tmpdir.join('dest').ensure_dir()
 
     src.join('__pycache__').ensure_dir()
-    format_files_to_directory(src, dest, {})
+    format_files(src, dest)
     assert not dest.join('__pycache__').exists()
-
-
-def test_cwd(tmpdir):
-    original_cwd = os.getcwd()
-    with cwd(tmpdir.strpath):
-        assert os.getcwd() == tmpdir.strpath
-    assert os.getcwd() == original_cwd
 
 
 @pytest.fixture
@@ -68,14 +60,15 @@ def in_git_dir(tmpdir):
         yield git_path
 
 
-def test_apply_version_and_commit(in_git_dir):
-    _apply_version_and_commit(
-        '0.24.1', 'ruby', 'scss-lint', r'\.scss$', 'scss-lint', (),
+def test_commit_version(in_git_dir):
+    _commit_version(
+        '.',
+        version='0.24.1', language='ruby', name='scss-lint', entry='scss-lint',
+        match_key='files', match_val=r'\.scss$', args='[]',
     )
 
     # Assert that our things got copied over
     assert in_git_dir.join('.pre-commit-hooks.yaml').exists()
-    assert in_git_dir.join('hooks.yaml').exists()
     assert in_git_dir.join('__fake_gem.gemspec').exists()
     # Assert that we set the version file correctly
     assert in_git_dir.join('.version').read().strip() == '0.24.1'
@@ -87,8 +80,10 @@ def test_apply_version_and_commit(in_git_dir):
 
 
 def test_arguments(in_git_dir):
-    _apply_version_and_commit(
-        '0.6.2', 'python', 'yapf', r'\.py$', 'yapf', ('-i',),
+    _commit_version(
+        '.',
+        version='0.6.2', language='python', name='yapf', entry='yapf',
+        match_key='files', match_val=r'\.py$', args='["-i"]',
     )
     contents = in_git_dir.join('.pre-commit-hooks.yaml').read()
     assert yaml.safe_load(contents) == [{
@@ -101,19 +96,22 @@ def test_arguments(in_git_dir):
     }]
 
 
-def returns_some_versions(_):
-    return ['0.23.1', '0.24.0', '0.24.1']
+@pytest.fixture
+def fake_versions():
+    fns = {'ruby': lambda _: ('0.23.1', '0.24.0', '0.24.1')}
+    with mock.patch.dict(LIST_VERSIONS, fns):
+        yield
 
 
-def test_make_repo_starting_empty(in_git_dir):
+def test_make_repo_starting_empty(in_git_dir, fake_versions):
     make_repo(
-        '.', 'ruby', 'scss-lint', r'\.scss$', 'scss-lint', (),
-        version_list_fn_map={'ruby': returns_some_versions},
+        '.',
+        language='ruby', name='scss-lint', entry='scss-lint',
+        match_key='files', match_val=r'\.scss$', args='[]',
     )
 
     # Assert that our things got copied over
     assert in_git_dir.join('.pre-commit-hooks.yaml').exists()
-    assert in_git_dir.join('hooks.yaml').exists()
     assert in_git_dir.join('__fake_gem.gemspec').exists()
     # Assert that we set the version fiel correctly
     assert in_git_dir.join('.version').read().strip() == '0.24.1'
@@ -131,14 +129,19 @@ def test_make_repo_starting_empty(in_git_dir):
     ]
 
 
-def test_make_repo_starting_at_version(in_git_dir):
+def test_make_repo_starting_at_version(in_git_dir, fake_versions):
     # Write a version file (as if we've already run this before)
     in_git_dir.join('.version').write('0.23.1')
+    # make sure this is gone afterwards
+    in_git_dir.join('hooks.yaml').ensure()
 
     make_repo(
-        '.', 'ruby', 'scss-lint', r'\.scss$', 'scss-lint', (),
-        version_list_fn_map={'ruby': returns_some_versions},
+        '.',
+        language='ruby', name='scss-lint', entry='scss-lint',
+        match_key='files', match_val=r'\.scss$', args='[]',
     )
+
+    assert not in_git_dir.join('hooks.yaml').exists()
 
     # Assert that we only got tags / commits for the stuff we added
     assert _cmd('git', 'tag', '-l').split() == ['v0.24.0', 'v0.24.1']
@@ -152,11 +155,14 @@ def test_make_repo_starting_at_version(in_git_dir):
 
 @pytest.mark.integration
 def test_ruby_integration(in_git_dir):
-    make_repo('.', 'ruby', 'scss-lint', r'\.scss$', 'scss-lint', ())
+    make_repo(
+        '.',
+        language='ruby', name='scss-lint', entry='scss-lint',
+        match_key='files', match_val=r'\.scss$', args='[]',
+    )
     # Our files should exist
     assert in_git_dir.join('.version').exists()
     assert in_git_dir.join('.pre-commit-hooks.yaml').exists()
-    assert in_git_dir.join('hooks.yaml').exists()
     assert in_git_dir.join('__fake_gem.gemspec').exists()
 
     # Should have made _some_ tags
@@ -169,11 +175,14 @@ def test_ruby_integration(in_git_dir):
 
 @pytest.mark.integration
 def test_node_integration(in_git_dir):
-    make_repo('.', 'node', 'jshint', r'\.js$', 'jshint', ())
+    make_repo(
+        '.',
+        language='node', name='jshint', entry='jshint',
+        match_key='files', match_val=r'\.js$', args='[]',
+    )
     # Our files should exist
     assert in_git_dir.join('.version').exists()
     assert in_git_dir.join('.pre-commit-hooks.yaml').exists()
-    assert in_git_dir.join('hooks.yaml').exists()
     assert in_git_dir.join('package.json').exists()
 
     # Should have made _some_ tags
@@ -185,11 +194,14 @@ def test_node_integration(in_git_dir):
 
 
 def test_python_integration(in_git_dir):
-    make_repo('.', 'python', 'flake8', r'\.py$', 'flake8', ())
+    make_repo(
+        '.',
+        language='python', name='flake8', entry='flake8',
+        match_key='files', match_val=r'\.py$', args='[]',
+    )
     # Our files should exist
     assert in_git_dir.join('.version').exists()
     assert in_git_dir.join('.pre-commit-hooks.yaml').exists()
-    assert in_git_dir.join('hooks.yaml').exists()
     assert in_git_dir.join('setup.py').exists()
 
     # Should have made _some_ tags


### PR DESCRIPTION
This does a few things that I plan to release in the next breaking release:

- stops writing `hooks.yaml` (and removes it from repository)
- Adds a `--types` option which can be passed 1 [identify](https://github.com/chriskuehl/identify) type
- changes to required-named-options

Resolves #21