### PR TITLE
Add support for language 'docker_image'

### DIFF
--- a/pre_commit_mirror_maker/docker_image/.pre-commit-hooks.yaml
+++ b/pre_commit_mirror_maker/docker_image/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: {id}
-    name: {name}
-    entry: {entry}
+    name: {id}
+    entry: '{entry}:{version}'
     language: {language}
     '{match_key}': {match_val}
     args: {args}

--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -6,6 +6,25 @@ from typing import List
 from packaging import version
 
 
+def docker_image_get_package_versions(image_name: str) -> List[str]:
+    """Returns the subset of tags that is formatted like versions.
+    I.e. this will not return the typical docker tag 'latest', but will return
+    tags like 'v1.2.3' or '1.2.3'.
+    See https://packaging.pypa.io/en/latest/version/ for more information.
+    """
+    if len(image_name.split('/')) != 2:
+        raise Exception(
+            'Only canonical DockerHub images <user>/<repo> supported.',
+        )
+    url = f'https://registry.hub.docker.com/v1/repositories/{image_name}/tags'
+    resp = json.load(urllib.request.urlopen(url))
+    versions = []
+    for tag in [info['name'] for info in resp]:
+        if isinstance(version.parse(tag), version.Version):
+            versions.append(tag)
+    return sorted(versions)
+
+
 def ruby_get_package_versions(package_name: str) -> List[str]:
     url = f'https://rubygems.org/api/v1/versions/{package_name}.json'
     resp = json.load(urllib.request.urlopen(url))
@@ -43,6 +62,7 @@ def rust_get_additional_dependencies(
 
 
 LIST_VERSIONS = {
+    'docker_image': docker_image_get_package_versions,
     'node': node_get_package_versions,
     'python': python_get_package_versions,
     'ruby': ruby_get_package_versions,

--- a/pre_commit_mirror_maker/main.py
+++ b/pre_commit_mirror_maker/main.py
@@ -53,6 +53,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         '--entry', help='Entry point, defaults to the package name.',
     )
     parser.add_argument(
+        '--id', help='Id, defaults to --entry.',
+    )
+    parser.add_argument(
         '--args',
         help=(
             'Comma separated arguments for the hook.  Escape commas in args '
@@ -67,11 +70,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    entry = args.entry or args.package_name
     make_repo(
         args.repo_path,
         name=args.package_name,
         language=args.language,
-        entry=args.entry or args.package_name,
+        entry=entry,
+        id=args.id or entry,
         match_key='types' if args.types else 'files',
         match_val=f'[{args.types}]' if args.types else args.files_regex,
         args=json.dumps(split_by_commas(args.args)),

--- a/pre_commit_mirror_maker/make_repo.py
+++ b/pre_commit_mirror_maker/make_repo.py
@@ -64,7 +64,8 @@ def _commit_version(
     # Commit and tag
     git('add', '.')
     git('commit', '-m', f'Mirror: {version}')
-    git('tag', f'v{version}')
+    tag = version if version.startswith('v') else f'v{version}'
+    git('tag', tag)
 
 
 def make_repo(repo: str, *, language: str, name: str, **fmt_vars: str) -> None:

--- a/tests/languages_test.py
+++ b/tests/languages_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pre_commit_mirror_maker.languages import docker_image_get_package_versions
 from pre_commit_mirror_maker.languages import node_get_package_versions
 from pre_commit_mirror_maker.languages import python_get_package_versions
 from pre_commit_mirror_maker.languages import ruby_get_package_versions
@@ -9,6 +10,19 @@ from pre_commit_mirror_maker.languages import rust_get_package_versions
 def assert_all_text(versions):
     for version in versions:
         assert type(version) is str
+
+
+@pytest.mark.integration
+def test_docker_image_get_package_version_output():
+    ret = docker_image_get_package_versions('mvdan/shfmt')
+    assert ret
+    assert_all_text(ret)
+
+
+@pytest.mark.integration
+def test_docker_image_get_package_version_output_fail():
+    with pytest.raises(Exception, match=r'Only canonical DockerHub images'):
+        docker_image_get_package_versions('my.repo.io:8080/my/image')
 
 
 @pytest.mark.integration

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -34,11 +34,12 @@ def test_main_passes_args(mock_make_repo):
         '--package-name', 'scss-lint',
         '--files-regex', r'\.scss$',
         '--entry', 'scss-lint-entry',
+        '--id', 'my-scss-lint',
     ))
     mock_make_repo.assert_called_once_with(
         '.',
         language='ruby', name='scss-lint', entry='scss-lint-entry',
-        match_key='files', match_val=r'\.scss$', args='[]',
+        id='my-scss-lint', match_key='files', match_val=r'\.scss$', args='[]',
         require_serial='false',
     )
 
@@ -51,6 +52,17 @@ def test_main_defaults_entry_to_package_name(mock_make_repo):
         '--files-regex', r'\.scss$',
     ))
     assert mock_make_repo.call_args[1]['entry'] == 'scss-lint'
+
+
+def test_main_defaults_id_to_entry(mock_make_repo):
+    assert not main.main((
+        '.',
+        '--language', 'docker_image',
+        '--package-name', 'mvdan/shfmt',
+        '--types', 'shell',
+        '--entry', 'shfmt',
+    ))
+    assert mock_make_repo.call_args[1]['id'] == 'shfmt'
 
 
 def test_main_with_args(mock_make_repo):

--- a/tests/make_repo_test.py
+++ b/tests/make_repo_test.py
@@ -64,7 +64,7 @@ def test_commit_version(in_git_dir):
     _commit_version(
         '.',
         version='0.24.1', language='ruby', name='scss-lint', entry='scss-lint',
-        match_key='files', match_val=r'\.scss$', args='[]',
+        id='scss-lint', match_key='files', match_val=r'\.scss$', args='[]',
         additional_dependencies='[]', require_serial='false',
     )
 
@@ -84,7 +84,7 @@ def test_arguments(in_git_dir):
     _commit_version(
         '.',
         version='0.6.2', language='python', name='yapf', entry='yapf',
-        match_key='files', match_val=r'\.py$', args='["-i"]',
+        id='yapf', match_key='files', match_val=r'\.py$', args='["-i"]',
         additional_dependencies='["scikit-learn"]', require_serial='false',
     )
     contents = in_git_dir.join('.pre-commit-hooks.yaml').read()
@@ -110,7 +110,7 @@ def fake_versions():
 def test_make_repo_starting_empty(in_git_dir, fake_versions):
     make_repo(
         '.',
-        language='ruby', name='scss-lint', entry='scss-lint',
+        language='ruby', name='scss-lint', entry='scss-lint', id='scss-lint',
         match_key='files', match_val=r'\.scss$', args='[]',
         require_serial='false',
     )
@@ -142,7 +142,7 @@ def test_make_repo_starting_at_version(in_git_dir, fake_versions):
 
     make_repo(
         '.',
-        language='ruby', name='scss-lint', entry='scss-lint',
+        language='ruby', name='scss-lint', entry='scss-lint', id='scss-lint',
         match_key='files', match_val=r'\.scss$', args='[]',
         require_serial='false',
     )
@@ -163,7 +163,7 @@ def test_make_repo_starting_at_version(in_git_dir, fake_versions):
 def test_ruby_integration(in_git_dir):
     make_repo(
         '.',
-        language='ruby', name='scss-lint', entry='scss-lint',
+        language='ruby', name='scss-lint', entry='scss-lint', id='scss-lint',
         match_key='files', match_val=r'\.scss$', args='[]',
         require_serial='false',
     )
@@ -184,7 +184,7 @@ def test_ruby_integration(in_git_dir):
 def test_node_integration(in_git_dir):
     make_repo(
         '.',
-        language='node', name='jshint', entry='jshint',
+        language='node', name='jshint', entry='jshint', id='jshint',
         match_key='files', match_val=r'\.js$', args='[]',
         require_serial='false',
     )
@@ -204,7 +204,7 @@ def test_node_integration(in_git_dir):
 def test_python_integration(in_git_dir):
     make_repo(
         '.',
-        language='python', name='flake8', entry='flake8',
+        language='python', name='flake8', entry='flake8', id='flake8',
         match_key='files', match_val=r'\.py$', args='[]',
         require_serial='false',
     )
@@ -229,8 +229,8 @@ def test_rust_integration(in_git_dir):
     make_repo(
         '.',
         language='rust', name='shellharden', entry='shellharden',
-        match_key='types', match_val='shell', args='["--replace"]',
-        require_serial='false',
+        id='shellharden', match_key='types', match_val='shell',
+        args='["--replace"]', require_serial='false',
     )
     # Our files should exist
     assert in_git_dir.join('.version').exists()
@@ -244,3 +244,21 @@ def test_rust_integration(in_git_dir):
     assert _cmd('git', 'log', '--oneline')
 
     # TODO: test that the package is installable
+
+
+@pytest.mark.integration
+def test_docker_image_integration(in_git_dir):
+    make_repo(
+        '.',
+        language='docker_image', name='mvdan/shfmt', entry='mvdan/shfmt',
+        id='shfmt', match_key='types', match_val='shell', args='[]',
+        require_serial='false',
+    )
+    # Our files should exist
+    assert in_git_dir.join('.version').exists()
+    assert in_git_dir.join('.pre-commit-hooks.yaml').exists()
+
+    # Should have made _some_ tags
+    assert _cmd('git', 'tag', '-l')
+    # Should have made _some_ commits
+    assert _cmd('git', 'log', '--oneline')


### PR DESCRIPTION
I hope to convince you to add an 'official mirror' for the [shfmt](https://github.com/mvdan/sh) tool.

I tried to [propose to the developer to add the .pre-config-hooks.yaml file to his repository](https://github.com/mvdan/sh/pull/465), but he declined, stating that he didn't want to maintain 'downstream packaging'. However, the developer does maintain a versioned docker image for the tool.

So the first step in creating a mirror would be the support for docker_image in your mirror maker. This PR should leave everything backward compatible, but I had to add a new --id flag since --repository_name and --entry have other meanings for docker_image already:
  * repository_name: Docker Hub's `<user>/<repo>` to pull existing tags
  * entry: potential override for .pre-commit-hook.yaml `entry` tag, e.g. to specify --entrypoint; defaults to prepository_name 
  * id: .pre-commit-hook.yaml `id` tag, i.e. how pre-commit calls the tool; defaults to entry
