### PR TITLE
Add option to set 'id'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ optional arguments:
   --files-regex FILES_REGEX
                         Files regex to use in hooks.yaml
   --types TYPES         `identify` type to match
+  --id ID               Hook id, defaults to the entry point.
   --entry ENTRY         Entry point, defaults to the package name.
   --args ARGS           Comma separated arguments for the hook. Escape commas
                         in args with a backslash (\). For example: --args='-i,

--- a/pre_commit_mirror_maker/all/.pre-commit-hooks.yaml
+++ b/pre_commit_mirror_maker/all/.pre-commit-hooks.yaml
@@ -1,4 +1,4 @@
--   id: {entry}
+-   id: {id}
     name: {name}
     entry: {entry}
     language: {language}

--- a/pre_commit_mirror_maker/main.py
+++ b/pre_commit_mirror_maker/main.py
@@ -50,6 +50,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     mutex.add_argument('--types', help='`identify` type to match')
 
     parser.add_argument(
+        '--id', help='Hook id, defaults to the entry point.',
+    )
+    parser.add_argument(
         '--entry', help='Entry point, defaults to the package name.',
     )
     parser.add_argument(
@@ -77,6 +80,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         name=args.package_name,
         language=args.language,
         entry=args.entry or args.package_name,
+        id=args.id or args.entry or args.package_name,
         match_key='types' if args.types else 'files',
         match_val=f'[{args.types}]' if args.types else args.files_regex,
         args=json.dumps(split_by_commas(args.args)),

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -34,11 +34,12 @@ def test_main_passes_args(mock_make_repo):
         '--package-name', 'scss-lint',
         '--files-regex', r'\.scss$',
         '--entry', 'scss-lint-entry',
+        '--id', 'scss-lint-id',
     ))
     mock_make_repo.assert_called_once_with(
         '.',
         language='ruby', name='scss-lint', entry='scss-lint-entry',
-        match_key='files', match_val=r'\.scss$', args='[]',
+        id='scss-lint-id', match_key='files', match_val=r'\.scss$', args='[]',
         require_serial='false', pass_filenames='false',
     )
 
@@ -51,6 +52,17 @@ def test_main_defaults_entry_to_package_name(mock_make_repo):
         '--files-regex', r'\.scss$',
     ))
     assert mock_make_repo.call_args[1]['entry'] == 'scss-lint'
+
+
+def test_main_defaults_id_to_entry(mock_make_repo):
+    assert not main.main((
+        '.',
+        '--language', 'ruby',
+        '--package-name', 'scss-lint',
+        '--entry', 'scss-lint',
+        '--files-regex', r'\.scss$',
+    ))
+    assert mock_make_repo.call_args[1]['id'] == 'scss-lint'
 
 
 def test_main_with_args(mock_make_repo):

--- a/tests/make_repo_test.py
+++ b/tests/make_repo_test.py
@@ -64,7 +64,7 @@ def test_commit_version(in_git_dir):
     _commit_version(
         '.',
         version='0.24.1', language='ruby', name='scss-lint', entry='scss-lint',
-        match_key='files', match_val=r'\.scss$', args='[]',
+        id='scss-lint', match_key='files', match_val=r'\.scss$', args='[]',
         additional_dependencies='[]', require_serial='false',
         pass_filenames='false',
     )
@@ -85,7 +85,7 @@ def test_arguments(in_git_dir):
     _commit_version(
         '.',
         version='0.6.2', language='python', name='yapf', entry='yapf',
-        match_key='files', match_val=r'\.py$', args='["-i"]',
+        id='yapf', match_key='files', match_val=r'\.py$', args='["-i"]',
         additional_dependencies='["scikit-learn"]', require_serial='false',
         pass_filenames='false',
     )
@@ -113,7 +113,7 @@ def fake_versions():
 def test_make_repo_starting_empty(in_git_dir, fake_versions):
     make_repo(
         '.',
-        language='ruby', name='scss-lint', entry='scss-lint',
+        language='ruby', name='scss-lint', entry='scss-lint', id='scss-lint',
         match_key='files', match_val=r'\.scss$', args='[]',
         require_serial='false', pass_filenames='false',
     )
@@ -145,7 +145,7 @@ def test_make_repo_starting_at_version(in_git_dir, fake_versions):
 
     make_repo(
         '.',
-        language='ruby', name='scss-lint', entry='scss-lint',
+        language='ruby', name='scss-lint', entry='scss-lint', id='scss-lint',
         match_key='files', match_val=r'\.scss$', args='[]',
         require_serial='false', pass_filenames='false',
     )
@@ -165,7 +165,7 @@ def test_make_repo_starting_at_version(in_git_dir, fake_versions):
 def test_ruby_integration(in_git_dir):
     make_repo(
         '.',
-        language='ruby', name='scss-lint', entry='scss-lint',
+        language='ruby', name='scss-lint', entry='scss-lint', id='scss-lint',
         match_key='files', match_val=r'\.scss$', args='[]',
         require_serial='false', pass_filenames='false',
     )
@@ -185,7 +185,7 @@ def test_ruby_integration(in_git_dir):
 def test_node_integration(in_git_dir):
     make_repo(
         '.',
-        language='node', name='jshint', entry='jshint',
+        language='node', name='jshint', entry='jshint', id='jshint',
         match_key='files', match_val=r'\.js$', args='[]',
         require_serial='false', pass_filenames='false',
     )
@@ -205,7 +205,7 @@ def test_node_integration(in_git_dir):
 def test_python_integration(in_git_dir):
     make_repo(
         '.',
-        language='python', name='flake8', entry='flake8',
+        language='python', name='flake8', entry='flake8', id='flake8',
         match_key='files', match_val=r'\.py$', args='[]',
         require_serial='false', pass_filenames='false',
     )
@@ -229,8 +229,8 @@ def test_rust_integration(in_git_dir):
     make_repo(
         '.',
         language='rust', name='shellharden', entry='shellharden',
-        match_key='types', match_val='shell', args='["--replace"]',
-        require_serial='false', pass_filenames='false',
+        id='shellharden', match_key='types', match_val='shell',
+        args='["--replace"]', require_serial='false', pass_filenames='false',
     )
     # Our files should exist
     assert in_git_dir.join('.version').exists()


### PR DESCRIPTION
This PR adds an option to set `id` independent of `entry`.

Is it ok that the `--id` option is before `--entry`, or should it rather go after?

I am not an expert in writing/running tests (this is the first time I used such), so I hope they are ok. Unfortunately, I did not manage to run them locally without a lot of failure output (also not master branch).

Closes #62