### PR TITLE
Use package.json's "dependencies" instal of additional_dependencies

### DIFF
--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -50,6 +50,5 @@ LIST_VERSIONS = {
 }
 
 ADDITIONAL_DEPENDENCIES = {
-    'node': node_get_additional_dependencies,
     'rust': rust_get_additional_dependencies,
 }

--- a/pre_commit_mirror_maker/node/package.json
+++ b/pre_commit_mirror_maker/node/package.json
@@ -1,5 +1,8 @@
 {{
     "name": "placeholder_package",
     "description": "Note: double curly-braces because python .format",
-    "version": "0.0.0"
+    "version": "0.0.0",
+    "dependencies": {{
+      "{name}": "{version}"
+    }}
 }}


### PR DESCRIPTION
# Why?

Because the current implementation makes the users clobber what the mirror sets on `additional_dependencies`. This pushes people into some non-pleasant hacks, like:

```yaml
     - repo: https://github.com/pre-commit/mirrors-prettier
       rev: v2.3.2 # Should match additional_dependencies and package-lock.json
       hooks:
           - id: prettier
             additional_dependencies:
                 # W/A: https://github.com/prettier/pre-commit/issues/16#issuecomment-713501862
                 - prettier@2.3.2  # Should match rev and package-lock.json
                 - 'my-cool-prettier-config@1.2.3' # Should match package-lock.json
```

This PR enables people to make things cleaner, and use node mirrors like:
```yaml
     - repo: https://github.com/pkoch/mirrors-prettier
       rev: 2.3.2 # Should match package-lock.json
       hooks:
           - id: prettier
             additional_dependencies:
                 - 'my-cool-prettier-config@1.2.3' # Should match package-lock.json
```

It's one less thing to keep in sync.

# How do I know it works?

Used https://github.com/pkoch/mirrors-prettier/, a mirror created with this PR (but I only tagged 2.3.2), with a variation of the config above. Worked as expected.