### PR TITLE
Use package.json's `"postinstall"` script instead of `additional_dependencies`

### DIFF
--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -50,6 +50,5 @@ LIST_VERSIONS = {
 }
 
 ADDITIONAL_DEPENDENCIES = {
-    'node': node_get_additional_dependencies,
     'rust': rust_get_additional_dependencies,
 }

--- a/pre_commit_mirror_maker/node/package.json
+++ b/pre_commit_mirror_maker/node/package.json
@@ -1,5 +1,8 @@
 {{
     "name": "placeholder_package",
     "description": "Note: double curly-braces because python .format",
-    "version": "0.0.0"
+    "version": "0.0.0",
+    "scripts": {{
+      "postinstall": "npm install {name}@{version}"
+    }}
 }}


### PR DESCRIPTION
Follow-up to https://github.com/pre-commit/pre-commit-mirror-maker/pull/101

# How do I know it works?

Generated https://github.com/pkoch/mirrors-prettier with this.
```
$ cd ~/github.com/pkoch/mirrors-prettier
$ pre-commit try-repo . --all-files
[INFO] Initializing environment for ..
===============================================================================
Using config:
===============================================================================
repos:
-   repo: .
    rev: 601acd0c62edba865eef26c9d27f6446174e2c9b
    hooks:
    -   id: prettier
===============================================================================
[INFO] Installing environment for ..
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
prettier.................................................................Failed
- hook id: prettier
- files were modified by this hook

.pre-commit-hooks.yaml
package.json
```
