### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,12 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py3-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38]
+    toxenvs: [py37, py38]
     os: linux

--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -1,30 +1,31 @@
+from __future__ import annotations
+
 import json
 import subprocess
 import urllib.request
-from typing import List
 
 from packaging import version
 
 
-def ruby_get_package_versions(package_name: str) -> List[str]:
+def ruby_get_package_versions(package_name: str) -> list[str]:
     url = f'https://rubygems.org/api/v1/versions/{package_name}.json'
     resp = json.load(urllib.request.urlopen(url))
     return list(reversed([version['number'] for version in resp]))
 
 
-def node_get_package_versions(package_name: str) -> List[str]:
+def node_get_package_versions(package_name: str) -> list[str]:
     cmd = ('npm', 'view', package_name, '--json')
     output = json.loads(subprocess.check_output(cmd))
     return output['versions']
 
 
-def python_get_package_versions(package_name: str) -> List[str]:
+def python_get_package_versions(package_name: str) -> list[str]:
     url = f'https://pypi.org/pypi/{package_name}/json'
     resp = json.load(urllib.request.urlopen(url))
     return sorted(resp['releases'], key=lambda k: version.parse(k))
 
 
-def rust_get_package_versions(package_name: str) -> List[str]:
+def rust_get_package_versions(package_name: str) -> list[str]:
     url = f'https://crates.io/api/v1/crates/{package_name}'
     resp = json.load(urllib.request.urlopen(url))
     return list(reversed([version['num'] for version in resp['versions']]))
@@ -32,13 +33,13 @@ def rust_get_package_versions(package_name: str) -> List[str]:
 
 def node_get_additional_dependencies(
         package_name: str, package_version: str,
-) -> List[str]:
+) -> list[str]:
     return [f'{package_name}@{package_version}']
 
 
 def rust_get_additional_dependencies(
         package_name: str, package_version: str,
-) -> List[str]:
+) -> list[str]:
     return [f'cli:{package_name}:{package_version}']
 
 

--- a/pre_commit_mirror_maker/main.py
+++ b/pre_commit_mirror_maker/main.py
@@ -1,22 +1,21 @@
+from __future__ import annotations
+
 import argparse
 import json
-from typing import List
-from typing import Optional
 from typing import Sequence
-from typing import Tuple
 
 from pre_commit_mirror_maker.make_repo import LIST_VERSIONS
 from pre_commit_mirror_maker.make_repo import make_repo
 
 
-def split_by_commas(maybe_s: str) -> Tuple[str, ...]:
+def split_by_commas(maybe_s: str) -> tuple[str, ...]:
     """Split a string by commas, but allow escaped commas.
     - If maybe_s is falsey, returns an empty tuple
     - Ignore backslashed commas
     """
     if not maybe_s:
         return ()
-    parts: List[str] = []
+    parts: list[str] = []
     split_by_backslash = maybe_s.split(r'\,')
     for split_by_backslash_part in split_by_backslash:
         splitby_comma = split_by_backslash_part.split(',')
@@ -28,7 +27,7 @@ def split_by_commas(maybe_s: str) -> Tuple[str, ...]:
     return tuple(parts)
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         'repo_path',

--- a/pre_commit_mirror_maker/make_repo.py
+++ b/pre_commit_mirror_maker/make_repo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os.path
 import subprocess

--- a/pre_commit_mirror_maker/python/setup.py
+++ b/pre_commit_mirror_maker/python/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
@@ -22,7 +21,7 @@ classifiers =
 [options]
 packages = find:
 install_requires = packaging
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/languages_test.py
+++ b/tests/languages_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pre_commit_mirror_maker.languages import node_get_package_versions
 from pre_commit_mirror_maker.languages import python_get_package_versions
 from pre_commit_mirror_maker.languages import ruby_get_package_versions

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/make_repo_test.py
+++ b/tests/make_repo_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 import sys
 from unittest import mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,pypy3,pre-commit
+envlist = py37,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos