### PR TITLE
produce a helpful error when --id is accidentally spaces

### DIFF
--- a/pre_commit_mirror_maker/main.py
+++ b/pre_commit_mirror_maker/main.py
@@ -88,13 +88,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         match_key = 'files'
         match_val = args.files_regex
 
+    hook_id = args.id or args.entry or args.package_name
+    if ' ' in hook_id:
+        raise SystemExit(
+            f'hook id should not contain spaces, perhaps specify --id?\n\n'
+            f'-   id: {hook_id}',
+        )
+
     make_repo(
         args.repo_path,
         name=args.package_name,
         description=args.description,
         language=args.language,
         entry=args.entry or args.package_name,
-        id=args.id or args.entry or args.package_name,
+        id=hook_id,
         match_key=match_key,
         match_val=match_val,
         args=json.dumps(split_by_commas(args.args)),

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -123,3 +123,19 @@ def test_main_types_or_multi(mock_make_repo):
     assert mock_make_repo.call_args[1]['match_key'] == 'types_or'
     assert mock_make_repo.call_args[1]['match_val'] == '[c++, c]'
     assert mock_make_repo.call_args[1]['minimum_pre_commit_version'] == '2.9.2'
+
+
+def test_main_errors_when_hook_id_has_spaces(mock_make_repo):
+    with pytest.raises(SystemExit) as excinfo:
+        main.main((
+            '.',
+            '--language', 'python',
+            '--package-name', 'clang-format',
+            '--entry', 'clang-format -i',
+            '--types', 'c',
+        ))
+    msg, = excinfo.value.args
+    assert msg == (
+        'hook id should not contain spaces, perhaps specify --id?\n\n'
+        '-   id: clang-format -i'
+    )


### PR DESCRIPTION
- https://github.com/pre-commit/mirrors-clang-format/pull/15
- https://github.com/pre-commit/mirrors-clang-format/issues/17