### PR TITLE
remove no_implicit_optional

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true
-no_implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 


### PR DESCRIPTION
this is the default in mypy 0.990

Committed via https://github.com/asottile/all-repos