### PR TITLE
Add "version-exclude" to command line arguments

### DIFF
--- a/pre_commit_mirror_maker/main.py
+++ b/pre_commit_mirror_maker/main.py
@@ -73,6 +73,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         '--require-serial', action='store_true',
         help='Set `require_serial: true` for the hook',
     )
+    parser.add_argument(
+        '--version-exclude', help='Version regex to exclude', default='!.*',
+    )
     args = parser.parse_args(argv)
 
     minimum_pre_commit_version = '0'
@@ -100,6 +103,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         name=args.package_name,
         description=args.description,
         language=args.language,
+        version_exclude=args.version_exclude,
         entry=args.entry or args.package_name,
         id=hook_id,
         match_key=match_key,

--- a/pre_commit_mirror_maker/make_repo.py
+++ b/pre_commit_mirror_maker/make_repo.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os.path
+import re
 import subprocess
 
 import pkg_resources
@@ -69,7 +70,13 @@ def _commit_version(
     git('tag', f'v{version}')
 
 
-def make_repo(repo: str, *, language: str, name: str, **fmt_vars: str) -> None:
+def make_repo(
+        repo: str, *,
+        language: str,
+        name: str,
+        version_exclude: str,
+        **fmt_vars: str,
+) -> None:
     assert os.path.exists(os.path.join(repo, '.git')), repo
 
     package_versions = LIST_VERSIONS[language](name)
@@ -82,6 +89,9 @@ def make_repo(repo: str, *, language: str, name: str, **fmt_vars: str) -> None:
         versions_to_apply = package_versions
 
     for version in versions_to_apply:
+        if re.match(version_exclude, version):
+            continue
+
         if language in ADDITIONAL_DEPENDENCIES:
             additional_dependencies = ADDITIONAL_DEPENDENCIES[language](
                 name,

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -44,6 +44,7 @@ def test_main_passes_args(mock_make_repo):
         entry='scss-lint-entry',
         id='scss-lint-id', match_key='files', match_val=r'\.scss$', args='[]',
         require_serial='false', minimum_pre_commit_version='0',
+        version_exclude='!.*',
     )
 
 


### PR DESCRIPTION
Make it possible to exclude unstable versions like `vX.X.X- alpha` `vX.X.X-beta` etc... from mirroring.

Ex. 
```shell
pre-commit-mirror mirrors-prisma --language node --package-name prisma --types javascript --version-exclude ".*-[alpha|beta|dev|integration]"
```