### PR TITLE
Sort npm package versions by their release date

### DIFF
--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 import urllib.request
+from operator import itemgetter
 
 from packaging import version
 
@@ -16,7 +17,12 @@ def ruby_get_package_versions(package_name: str) -> list[str]:
 def node_get_package_versions(package_name: str) -> list[str]:
     cmd = ('npm', 'view', package_name, '--json')
     output = json.loads(subprocess.check_output(cmd))
-    return output['versions']
+    versions = [
+        (k, v) for k, v in output['time'].items()
+        if k not in {'created', 'modified'}
+    ]
+    versions.sort(key=itemgetter(1))
+    return list(map(itemgetter(0), versions))
 
 
 def python_get_package_versions(package_name: str) -> list[str]:


### PR DESCRIPTION
This will help ensure releases aren't missed due to them being released out of order.

It makes use of the "time" dictionary from the npm output, which has a key of the release version and a value of when the version was released.

The "versions" list only had a sorted list of all released versions, which meant Prettier 2.8.0 for instance was skipped in https://github.com/pre-commit/mirrors-prettier/issues/29, because 3.0.0-alpha.X releases already had been made before 2.8.0 was released.

Let me know if you'd like a test for this.