### PR TITLE
Exclude beta releases in npm

### DIFF
--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -15,7 +15,7 @@ def ruby_get_package_versions(package_name: str) -> list[str]:
 
 def node_get_package_versions(package_name: str) -> list[str]:
     # Excludes beta releases
-    cmd = ('npm', 'view', f'"{package_name}@*"', 'version', '--json')
+    cmd = ('npm', 'view', f'{package_name}@*', 'version', '--json')
     return json.loads(subprocess.check_output(cmd))
 
 

--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -14,9 +14,9 @@ def ruby_get_package_versions(package_name: str) -> list[str]:
 
 
 def node_get_package_versions(package_name: str) -> list[str]:
-    cmd = ('npm', 'view', package_name, '--json')
-    output = json.loads(subprocess.check_output(cmd))
-    return output['versions']
+    # Excludes beta releases
+    cmd = ('npm', 'view', f'"{package_name}@*"', 'version', '--json')
+    return json.loads(subprocess.check_output(cmd))
 
 
 def python_get_package_versions(package_name: str) -> list[str]:


### PR DESCRIPTION
- Should fix https://github.com/pre-commit/mirrors-prettier/issues/29

Versions released outside the stable branch should not be used in production. This PR makes a small change to natively filter unstable versions.

Try this:
```sh
npm view "prettier@*" version --json
```

```
[
  "0.0.1",
  "0.0.2",
  "0.0.3",
  "0.0.4",
  "0.0.5",
  "0.0.6",
  "0.0.7",
  "0.0.8",
  "0.0.9",
  "0.0.10",
  "0.11.0",
  "0.13.1",
  "0.14.0",
  "0.14.1",
  "0.15.0",
  "0.16.0",
  "0.17.0",
  "0.17.1",
  "0.18.0",
  "0.19.0",
  "0.20.0",
  "0.21.0",
  "0.22.0",
  "1.0.0",
  "1.0.1",
  "1.0.2",
  "1.1.0",
  "1.2.0",
  "1.2.1",
  "1.2.2",
  "1.3.0",
  "1.3.1",
  "1.4.0",
  "1.4.1",
  "1.4.2",
  "1.4.3",
  "1.4.4",
  "1.5.0",
  "1.5.1",
  "1.5.2",
  "1.5.3",
  "1.6.0",
  "1.6.1",
  "1.7.0",
  "1.7.1",
  "1.7.2",
  "1.7.3",
  "1.7.4",
  "1.8.0",
  "1.8.1",
  "1.8.2",
  "1.9.0",
  "1.9.1",
  "1.9.2",
  "1.10.0",
  "1.10.1",
  "1.10.2",
  "1.11.0",
  "1.11.1",
  "1.12.0",
  "1.12.1",
  "1.13.0",
  "1.13.1",
  "1.13.2",
  "1.13.3",
  "1.13.4",
  "1.13.5",
  "1.13.6",
  "1.13.7",
  "1.14.0",
  "1.14.1",
  "1.14.2",
  "1.14.3",
  "1.15.0",
  "1.15.1",
  "1.15.2",
  "1.15.3",
  "1.16.0",
  "1.16.1",
  "1.16.2",
  "1.16.3",
  "1.16.4",
  "1.17.0",
  "1.17.1",
  "1.18.0",
  "1.18.1",
  "1.18.2",
  "1.19.0",
  "1.19.1",
  "2.0.0",
  "2.0.1",
  "2.0.2",
  "2.0.3",
  "2.0.4",
  "2.0.5",
  "2.1.0",
  "2.1.1",
  "2.1.2",
  "2.2.0",
  "2.2.1",
  "2.3.0",
  "2.3.1",
  "2.3.2",
  "2.4.0",
  "2.4.1",
  "2.5.0",
  "2.5.1",
  "2.6.0",
  "2.6.1",
  "2.6.2",
  "2.7.0",
  "2.7.1",
  "2.8.0",
  "2.8.1"
]
```

Related:

- https://stackoverflow.com/a/51308597/288906