### PR TITLE
Support user-provided hook names via `--name`

### DIFF
--- a/pre_commit_mirror_maker/main.py
+++ b/pre_commit_mirror_maker/main.py
@@ -42,6 +42,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         help='Package name as it appears on the remote package manager.',
     )
     parser.add_argument(
+        '--name',
+        help=(
+            'Hook name, displayed as a message during pre-commit runs. '
+            'Defaults to the package name.'
+        ),
+    )
+    parser.add_argument(
         '--description', help='Hook description.', default='',
     )
 
@@ -97,7 +104,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     make_repo(
         args.repo_path,
-        name=args.package_name,
+        package_name=args.package_name,
+        name=args.name or args.package_name,
         description=args.description,
         language=args.language,
         entry=args.entry or args.package_name,

--- a/pre_commit_mirror_maker/make_repo.py
+++ b/pre_commit_mirror_maker/make_repo.py
@@ -69,10 +69,15 @@ def _commit_version(
     git('tag', f'v{version}')
 
 
-def make_repo(repo: str, *, language: str, name: str, **fmt_vars: str) -> None:
+def make_repo(
+        repo: str, *,
+        language: str,
+        package_name: str,
+        **fmt_vars: str,
+) -> None:
     assert os.path.exists(os.path.join(repo, '.git')), repo
 
-    package_versions = LIST_VERSIONS[language](name)
+    package_versions = LIST_VERSIONS[language](package_name)
     version_file = os.path.join(repo, '.version')
     if os.path.exists(version_file):
         previous_version = open(version_file).read().strip()
@@ -84,7 +89,7 @@ def make_repo(repo: str, *, language: str, name: str, **fmt_vars: str) -> None:
     for version in versions_to_apply:
         if language in ADDITIONAL_DEPENDENCIES:
             additional_dependencies = ADDITIONAL_DEPENDENCIES[language](
-                name,
+                package_name,
                 version,
             )
         else:
@@ -92,7 +97,7 @@ def make_repo(repo: str, *, language: str, name: str, **fmt_vars: str) -> None:
 
         _commit_version(
             repo,
-            name=name,
+            package_name=package_name,
             language=language,
             version=version,
             additional_dependencies=json.dumps(additional_dependencies),

--- a/pre_commit_mirror_maker/python/setup.py
+++ b/pre_commit_mirror_maker/python/setup.py
@@ -6,5 +6,5 @@ from setuptools import setup
 setup(
     name='pre_commit_placeholder_package',
     version='0.0.0',
-    install_requires=['{name}=={version}'],
+    install_requires=['{package_name}=={version}'],
 )

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -40,11 +40,21 @@ def test_main_passes_args(mock_make_repo):
     ))
     mock_make_repo.assert_called_once_with(
         '.',
-        language='ruby', name='scss-lint', description='',
-        entry='scss-lint-entry',
+        language='ruby', package_name='scss-lint', name='scss-lint',
+        description='', entry='scss-lint-entry',
         id='scss-lint-id', match_key='files', match_val=r'\.scss$', args='[]',
         require_serial='false', minimum_pre_commit_version='0',
     )
+
+
+def test_main_defaults_name_to_package_name(mock_make_repo):
+    assert not main.main((
+        '.',
+        '--language', 'ruby',
+        '--package-name', 'scss-lint',
+        '--files-regex', r'\.scss$',
+    ))
+    assert mock_make_repo.call_args[1]['name'] == 'scss-lint'
 
 
 def test_main_defaults_entry_to_package_name(mock_make_repo):
@@ -66,6 +76,18 @@ def test_main_defaults_id_to_entry(mock_make_repo):
         '--files-regex', r'\.scss$',
     ))
     assert mock_make_repo.call_args[1]['id'] == 'scss-lint'
+
+
+def test_main_with_name(mock_make_repo):
+    assert not main.main((
+        '.',
+        '--language', 'python',
+        '--package-name', 'yapf',
+        '--files-regex', r'\.py$',
+        '--name="Run yapf"',
+    ))
+    expected = '"Run yapf"'
+    assert mock_make_repo.call_args[1]['name'] == expected
 
 
 def test_main_with_args(mock_make_repo):

--- a/tests/make_repo_test.py
+++ b/tests/make_repo_test.py
@@ -65,10 +65,11 @@ def in_git_dir(tmpdir):
 def test_commit_version(in_git_dir):
     _commit_version(
         '.',
-        version='0.24.1', language='ruby', name='scss-lint', description='',
-        entry='scss-lint', id='scss-lint', match_key='files',
-        match_val=r'\.scss$', args='[]', additional_dependencies='[]',
-        require_serial='false', minimum_pre_commit_version='0',
+        version='0.24.1', language='ruby', package_name='scss-lint',
+        name='scss-lint', description='', entry='scss-lint', id='scss-lint',
+        match_key='files', match_val=r'\.scss$', args='[]',
+        additional_dependencies='[]', require_serial='false',
+        minimum_pre_commit_version='0',
     )
 
     # Assert that our things got copied over
@@ -86,16 +87,16 @@ def test_commit_version(in_git_dir):
 def test_arguments(in_git_dir):
     _commit_version(
         '.',
-        version='0.6.2', language='python', name='yapf',
-        description='Yet another Python formatter.', entry='yapf', id='yapf',
-        match_key='files', match_val=r'\.py$', args='["-i"]',
-        additional_dependencies='["scikit-learn"]', require_serial='false',
-        minimum_pre_commit_version='0',
+        version='0.6.2', language='python', package_name='yapf',
+        name='Run yapf', description='Yet another Python formatter.',
+        entry='yapf', id='yapf', match_key='files', match_val=r'\.py$',
+        args='["-i"]', additional_dependencies='["scikit-learn"]',
+        require_serial='false', minimum_pre_commit_version='0',
     )
     contents = in_git_dir.join('.pre-commit-hooks.yaml').read()
     assert yaml.safe_load(contents) == [{
         'id': 'yapf',
-        'name': 'yapf',
+        'name': 'Run yapf',
         'description': 'Yet another Python formatter.',
         'entry': 'yapf',
         'language': 'python',
@@ -117,9 +118,10 @@ def fake_versions():
 def test_make_repo_starting_empty(in_git_dir, fake_versions):
     make_repo(
         '.',
-        language='ruby', name='scss-lint', description='', entry='scss-lint',
-        id='scss-lint', match_key='files', match_val=r'\.scss$', args='[]',
-        require_serial='false', minimum_pre_commit_version='0',
+        language='ruby', package_name='scss-lint', name='scss-lint',
+        description='', entry='scss-lint', id='scss-lint', match_key='files',
+        match_val=r'\.scss$', args='[]', require_serial='false',
+        minimum_pre_commit_version='0',
     )
 
     # Assert that our things got copied over
@@ -149,9 +151,10 @@ def test_make_repo_starting_at_version(in_git_dir, fake_versions):
 
     make_repo(
         '.',
-        language='ruby', name='scss-lint', description='', entry='scss-lint',
-        id='scss-lint', match_key='files', match_val=r'\.scss$', args='[]',
-        require_serial='false', minimum_pre_commit_version='0',
+        language='ruby', package_name='scss-lint', name='scss-lint',
+        description='', entry='scss-lint', id='scss-lint', match_key='files',
+        match_val=r'\.scss$', args='[]', require_serial='false',
+        minimum_pre_commit_version='0',
     )
 
     assert not in_git_dir.join('hooks.yaml').exists()
@@ -169,9 +172,10 @@ def test_make_repo_starting_at_version(in_git_dir, fake_versions):
 def test_ruby_integration(in_git_dir):
     make_repo(
         '.',
-        language='ruby', name='scss-lint', description='', entry='scss-lint',
-        id='scss-lint', match_key='files', match_val=r'\.scss$', args='[]',
-        require_serial='false', minimum_pre_commit_version='0',
+        language='ruby', package_name='scss-lint', name='scss-lint',
+        description='', entry='scss-lint', id='scss-lint', match_key='files',
+        match_val=r'\.scss$', args='[]', require_serial='false',
+        minimum_pre_commit_version='0',
     )
     # Our files should exist
     assert in_git_dir.join('.version').exists()
@@ -189,9 +193,9 @@ def test_ruby_integration(in_git_dir):
 def test_node_integration(in_git_dir):
     make_repo(
         '.',
-        language='node', name='jshint', description='', entry='jshint',
-        id='jshint', match_key='files', match_val=r'\.js$', args='[]',
-        require_serial='false', minimum_pre_commit_version='0',
+        language='node', package_name='jshint', name='jshint', description='',
+        entry='jshint', id='jshint', match_key='files', match_val=r'\.js$',
+        args='[]', require_serial='false', minimum_pre_commit_version='0',
     )
     # Our files should exist
     assert in_git_dir.join('.version').exists()
@@ -209,9 +213,10 @@ def test_node_integration(in_git_dir):
 def test_python_integration(in_git_dir):
     make_repo(
         '.',
-        language='python', name='flake8', description='', entry='flake8',
-        id='flake8', match_key='files', match_val=r'\.py$', args='[]',
-        require_serial='false', minimum_pre_commit_version='0',
+        language='python', package_name='flake8', name='flake8',
+        description='', entry='flake8', id='flake8', match_key='files',
+        match_val=r'\.py$', args='[]', require_serial='false',
+        minimum_pre_commit_version='0',
     )
     # Our files should exist
     assert in_git_dir.join('.version').exists()
@@ -223,7 +228,7 @@ def test_python_integration(in_git_dir):
     # Should have made _some_ commits
     assert _cmd('git', 'log', '--oneline')
 
-    # To make sure the name is valid
+    # To make sure the package name is valid
     subprocess.check_call((sys.executable, 'setup.py', 'egg_info'))
 
     # TODO: test that the package is installable
@@ -232,10 +237,10 @@ def test_python_integration(in_git_dir):
 def test_rust_integration(in_git_dir):
     make_repo(
         '.',
-        language='rust', name='shellharden', description='',
-        entry='shellharden', id='shellharden', match_key='types',
-        match_val='shell', args='["--replace"]', require_serial='false',
-        minimum_pre_commit_version='0',
+        language='rust', package_name='shellharden', name='shellharden',
+        description='', entry='shellharden', id='shellharden',
+        match_key='types', match_val='shell', args='["--replace"]',
+        require_serial='false', minimum_pre_commit_version='0',
     )
     # Our files should exist
     assert in_git_dir.join('.version').exists()


### PR DESCRIPTION
Until now, package_name and name were identical. This change allows the user to provide a custom hook name which will then be used as the `name` in the created hook.

As `name` is visible in a status message when
pre-commit runs, this allows to improve user experience by providing messages like "Check XYZ formatting" instead of using the package name like "xyz-format".

Usage of `name` and `package_name` in code are now disambiguated through renaming.