### PR TITLE
feat: support python extras

### DIFF
--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import urllib.request
 
+from packaging import requirements
 from packaging import version
 
 
@@ -20,7 +21,8 @@ def node_get_package_versions(package_name: str) -> list[str]:
 
 
 def python_get_package_versions(package_name: str) -> list[str]:
-    url = f'https://pypi.org/pypi/{package_name}/json'
+    pypi_name = requirements.Requirement(package_name).name
+    url = f'https://pypi.org/pypi/{pypi_name}/json'
     resp = json.load(urllib.request.urlopen(url))
     return sorted(resp['releases'], key=lambda k: version.parse(k))
 

--- a/tests/languages_test.py
+++ b/tests/languages_test.py
@@ -23,6 +23,12 @@ def test_python_get_package_version_output():
     assert_all_text(ret)
 
 
+def test_python_get_package_version_extras_output():
+    ret = python_get_package_versions('bandit[yaml]')
+    assert ret
+    assert_all_text(ret)
+
+
 def test_ruby_get_package_version_output():
     ret = ruby_get_package_versions('scss-lint')
     assert ret


### PR DESCRIPTION
Closes #63. Tested with the original example, with an `--id` added:

```bash
pre-commit-mirror mirrors-CleverCSV --language python --package-name "clevercsv[full]" --entry "clevercsv standardize" --args="--in-place" --types csv --id clevercsv
```

The resulting repo seems to be right, the setup.py is correct, and I added a test for the pypi URLs part.

(I need this for repo-review as well, which needs the `[cli]` extra to work).
