### PR TITLE
For node, only return versions up to the current release

### DIFF
--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -17,13 +17,13 @@ def ruby_get_package_versions(package_name: str) -> list[str]:
 def node_get_package_versions(package_name: str) -> list[str]:
     cmd = ('npm', 'view', package_name, '--json')
     output = json.loads(subprocess.check_output(cmd))
-    try:
-        latest = output['dist-tags']['latest']
-        latest_index = output['versions'].index(latest)
-        return output['versions'][:latest_index + 1]
-    except (KeyError, ValueError):
-        return output['versions']
-
+    versions = output['versions']
+    dist_tags = output.get('dist-tags', {})
+    latest = dist_tags.get('latest')
+    latest_index = (
+        versions.index(latest) if latest in versions else len(versions)
+    )
+    return output['versions'][: latest_index + 1]
 
 def python_get_package_versions(package_name: str) -> list[str]:
     pypi_name = requirements.Requirement(package_name).name

--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -25,6 +25,7 @@ def node_get_package_versions(package_name: str) -> list[str]:
     )
     return output['versions'][: latest_index + 1]
 
+
 def python_get_package_versions(package_name: str) -> list[str]:
     pypi_name = requirements.Requirement(package_name).name
     url = f'https://pypi.org/pypi/{pypi_name}/json'

--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -17,7 +17,12 @@ def ruby_get_package_versions(package_name: str) -> list[str]:
 def node_get_package_versions(package_name: str) -> list[str]:
     cmd = ('npm', 'view', package_name, '--json')
     output = json.loads(subprocess.check_output(cmd))
-    return output['versions']
+    try:
+        latest = output['dist-tags']['latest']
+        latest_index = output['versions'].index(latest)
+        return output['versions'][:latest_index + 1]
+    except (KeyError, ValueError):
+        return output['versions']
 
 
 def python_get_package_versions(package_name: str) -> list[str]:


### PR DESCRIPTION
Prior to this change `node_get_package_versions` would include unreleased versions, e.g. alpha versions. As of the time of writing this was happening, e.g., with 'prettier'.