### PR TITLE
Sort node package versions by release date

### DIFF
--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -18,12 +18,9 @@ def _node_get_package_versions(package_json):
     versions = package_json['versions']
     version_timestamps = package_json['time']
 
-    def version_timestamp(e):
-        return version_timestamps.get(e, "")
-
     # Sort the versions according to their timestamps, to prevent versions
     # from being missed if they get released out of order.
-    versions.sort(key=version_timestamp)
+    versions.sort(key=lambda e: version_timestamps.get(e, ""))
     return versions
 
 

--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -14,10 +14,23 @@ def ruby_get_package_versions(package_name: str) -> list[str]:
     return list(reversed([version['number'] for version in resp]))
 
 
+def _node_get_package_versions(package_json):
+    versions = package_json['versions']
+    version_timestamps = package_json['time']
+
+    def version_timestamp(e):
+        return version_timestamps.get(e, "")
+
+    # Sort the versions according to their timestamps, to prevent versions
+    # from being missed if they get released out of order.
+    versions.sort(key=version_timestamp)
+    return versions
+
+
 def node_get_package_versions(package_name: str) -> list[str]:
     cmd = ('npm', 'view', package_name, '--json')
-    output = json.loads(subprocess.check_output(cmd))
-    return output['versions']
+    output = json.loads(subprocess.check_output(cmd, shell=True))
+    return _node_get_package_versions(output)
 
 
 def python_get_package_versions(package_name: str) -> list[str]:

--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 import urllib.request
+from typing import Any
 
 from packaging import requirements
 from packaging import version
@@ -14,19 +15,19 @@ def ruby_get_package_versions(package_name: str) -> list[str]:
     return list(reversed([version['number'] for version in resp]))
 
 
-def _node_get_package_versions(package_json):
+def _node_get_package_versions(package_json: dict[str, Any]) -> list[str]:
     versions = package_json['versions']
     version_timestamps = package_json['time']
 
     # Sort the versions according to their timestamps, to prevent versions
     # from being missed if they get released out of order.
-    versions.sort(key=lambda e: version_timestamps.get(e, ""))
+    versions.sort(key=lambda e: version_timestamps.get(e, ''))
     return versions
 
 
 def node_get_package_versions(package_name: str) -> list[str]:
     cmd = ('npm', 'view', package_name, '--json')
-    output = json.loads(subprocess.check_output(cmd, shell=True))
+    output = json.loads(subprocess.check_output(cmd))
     return _node_get_package_versions(output)
 
 

--- a/tests/languages_test.py
+++ b/tests/languages_test.py
@@ -11,38 +11,39 @@ def assert_all_text(versions):
     for version in versions:
         assert type(version) is str
 
+
 def test__node_get_package_version_output():
     package_json = {
         # versions sorted according to number
-        "versions": [
-            "1.0.0",
-            "2.0.0",
-            "2.0.1",
-            "2.0.2",
-            "3.0.0-beta",
-            "3.0.1-beta",
-            "3.0.2",
+        'versions': [
+            '1.0.0',
+            '2.0.0',
+            '2.0.1',
+            '2.0.2',
+            '3.0.0-beta',
+            '3.0.1-beta',
+            '3.0.2',
         ],
         # versions released out of order
-        "time": {
-            "1.0.0": "2017-01-10T03:45:38.963Z",
-            "2.0.0": "2017-01-10T04:31:28.120Z",
-            "3.0.0-beta": "2017-01-10T17:18:52.417Z",
-            "2.0.1": "2017-01-11T04:52:50.871Z",
-            "3.0.1-beta": "2017-01-11T08:55:07.338Z",
-            "2.0.2": "2017-01-11T16:55:07.338Z",
-            "3.0.2": "2017-01-13T20:14:11.275Z",
-        }
+        'time': {
+            '1.0.0': '2017-01-10T03:45:38.963Z',
+            '2.0.0': '2017-01-10T04:31:28.120Z',
+            '3.0.0-beta': '2017-01-10T17:18:52.417Z',
+            '2.0.1': '2017-01-11T04:52:50.871Z',
+            '3.0.1-beta': '2017-01-11T08:55:07.338Z',
+            '2.0.2': '2017-01-11T16:55:07.338Z',
+            '3.0.2': '2017-01-13T20:14:11.275Z',
+        },
     }
     # return versions matches the order they were release in
     assert _node_get_package_versions(package_json) == [
-        "1.0.0",
-        "2.0.0",
-        "3.0.0-beta",
-        "2.0.1",
-        "3.0.1-beta",
-        "2.0.2",
-        "3.0.2",
+        '1.0.0',
+        '2.0.0',
+        '3.0.0-beta',
+        '2.0.1',
+        '3.0.1-beta',
+        '2.0.2',
+        '3.0.2',
     ]
 
 

--- a/tests/languages_test.py
+++ b/tests/languages_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pre_commit_mirror_maker.languages import _node_get_package_versions
 from pre_commit_mirror_maker.languages import node_get_package_versions
 from pre_commit_mirror_maker.languages import python_get_package_versions
 from pre_commit_mirror_maker.languages import ruby_get_package_versions
@@ -9,6 +10,40 @@ from pre_commit_mirror_maker.languages import rust_get_package_versions
 def assert_all_text(versions):
     for version in versions:
         assert type(version) is str
+
+def test__node_get_package_version_output():
+    package_json = {
+        # versions sorted according to number
+        "versions": [
+            "1.0.0",
+            "2.0.0",
+            "2.0.1",
+            "2.0.2",
+            "3.0.0-beta",
+            "3.0.1-beta",
+            "3.0.2",
+        ],
+        # versions released out of order
+        "time": {
+            "1.0.0": "2017-01-10T03:45:38.963Z",
+            "2.0.0": "2017-01-10T04:31:28.120Z",
+            "3.0.0-beta": "2017-01-10T17:18:52.417Z",
+            "2.0.1": "2017-01-11T04:52:50.871Z",
+            "3.0.1-beta": "2017-01-11T08:55:07.338Z",
+            "2.0.2": "2017-01-11T16:55:07.338Z",
+            "3.0.2": "2017-01-13T20:14:11.275Z",
+        }
+    }
+    # return versions matches the order they were release in
+    assert _node_get_package_versions(package_json) == [
+        "1.0.0",
+        "2.0.0",
+        "3.0.0-beta",
+        "2.0.1",
+        "3.0.1-beta",
+        "2.0.2",
+        "3.0.2",
+    ]
 
 
 def test_node_get_package_version_output():


### PR DESCRIPTION
[issue](https://github.com/pre-commit/pre-commit-mirror-maker/issues/213)

This PR solves the issue of Node package versions being missed if the target repo released versions out of order.