### PR TITLE
Draft: Allow making mirror for specific version

### DIFF
--- a/pre_commit_mirror_maker/languages.py
+++ b/pre_commit_mirror_maker/languages.py
@@ -16,7 +16,7 @@ def ruby_get_package_versions(package_name: str) -> list[str]:
 
 def node_get_package_versions(package_name: str) -> list[str]:
     cmd = ('npm', 'view', package_name, '--json')
-    output = json.loads(subprocess.check_output(cmd))
+    output = json.loads(subprocess.check_output(cmd, shell=True))
     return output['versions']
 
 

--- a/pre_commit_mirror_maker/main.py
+++ b/pre_commit_mirror_maker/main.py
@@ -73,6 +73,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         '--require-serial', action='store_true',
         help='Set `require_serial: true` for the hook',
     )
+    parser.add_argument(
+        '--target-version',
+        help=(
+            'Create a mirror for a specific version of the target package. '
+            'This action won''t update the .version file. '
+        ),
+    )
     args = parser.parse_args(argv)
 
     minimum_pre_commit_version = '0'
@@ -107,6 +114,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args=json.dumps(split_by_commas(args.args)),
         require_serial=json.dumps(args.require_serial),
         minimum_pre_commit_version=minimum_pre_commit_version,
+        target_version=args.target_version,
     )
     return 0
 

--- a/pre_commit_mirror_maker/make_repo.py
+++ b/pre_commit_mirror_maker/make_repo.py
@@ -10,7 +10,9 @@ from pre_commit_mirror_maker.languages import LIST_VERSIONS
 
 
 def format_files(
-    src: os.PathLike[str], dest: str, ignored_files: list[str],
+    src: os.PathLike[str],
+    dest: str,
+    ignored_files: list[str],
     **fmt_vars: str,
 ) -> None:
     """Copies all files inside src into dest while formatting the contents
@@ -47,11 +49,12 @@ def format_files(
 
 
 def _commit_version(
-        repo: str, *,
-        language: str,
-        version: str,
-        skip_version_file: bool,
-        **fmt_vars: str,
+    repo: str,
+    *,
+    language: str,
+    version: str,
+    skip_version_file: bool,
+    **fmt_vars: str,
 ) -> None:
     # 'all' writes the .version and .pre-commit-hooks.yaml files
     files = importlib.resources.files('pre_commit_mirror_maker')
@@ -63,9 +66,9 @@ def _commit_version(
                 repo,
                 language=language,
                 version=version,
-                ignored_files=['.version']
-                if lang == 'all' and skip_version_file
-                else [],
+                ignored_files=(
+                    ['.version'] if lang == 'all' and skip_version_file else []
+                ),
                 **fmt_vars,
             )
 
@@ -83,7 +86,11 @@ def _commit_version(
 
 
 def make_repo(
-    repo: str, *, language: str, name: str, target_version: str,
+    repo: str,
+    *,
+    language: str,
+    name: str,
+    target_version: str,
     **fmt_vars: str,
 ) -> None:
     assert os.path.exists(os.path.join(repo, '.git')), repo
@@ -92,8 +99,7 @@ def make_repo(
     if target_version:
         if target_version not in package_versions:
             raise SystemExit(
-                f'target version {target_version} not found for '
-                'the package',
+                f"target version {target_version} not found for the package",
             )
         versions_to_apply = [target_version]
     else:

--- a/pre_commit_mirror_maker/make_repo.py
+++ b/pre_commit_mirror_maker/make_repo.py
@@ -99,7 +99,7 @@ def make_repo(
     if target_version:
         if target_version not in package_versions:
             raise SystemExit(
-                f"target version {target_version} not found for the package",
+                f'target version {target_version} not found for the package',
             )
         versions_to_apply = [target_version]
     else:


### PR DESCRIPTION
This PR allows specific versions of the target repo to be made, while not updating the `.version` file. The main reason for adding this feature is to allow users to add missed versions to a mirror repo because of the issue mentioned in #213 .